### PR TITLE
added required npm for website builder

### DIFF
--- a/odoo-v8/ubuntu-14-04/odoo_install.sh
+++ b/odoo-v8/ubuntu-14-04/odoo_install.sh
@@ -59,7 +59,11 @@ sudo apt-get install python-dateutil python-feedparser python-ldap python-libxsl
 	
 echo -e "\n---- Install python libraries ----"
 sudo pip install gdata
-	
+
+echo -e "\n---- Install dependencies ----"
+sudo apt-get install npm
+sudo npm install -g less
+
 echo -e "\n---- Create ODOO system user ----"
 sudo adduser --system --quiet --shell=/bin/bash --home=$OE_HOME --gecos 'ODOO' --group $OE_USER
 


### PR DESCRIPTION
The website builder requires npm less or else throws
"could not execute command 'lessc'" when editing themes.
https://www.odoo.com/forum/help-1/question/what-does-this-error-mean-on-odoo-could-not-execute-command-lessc-60439
