### PR TITLE
Fix Pillow install with Pip

### DIFF
--- a/odoo-v8/debian-7/odoo_install.sh
+++ b/odoo-v8/debian-7/odoo_install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ################################################################################
 # Script for Installation: ODOO 8 server on Debian 7
-# Author: André Schenkels, ICTSTUDIO 2014
+# Author: AndrÃ© Schenkels, ICTSTUDIO 2014
 #-------------------------------------------------------------------------------
 #  
 # This script will install ODOO Server on
@@ -55,7 +55,7 @@ echo -e "\n---- Install tool packages ----"
 apt-get install wget subversion git bzr bzrtools python-pip -y
 	
 echo -e "\n---- Install python packages ----"
-apt-get install python-dateutil python-feedparser python-ldap python-libxslt1 python-lxml python-mako python-openid python-psycopg2 python-pybabel python-pychart python-pydot python-pyparsing python-reportlab python-simplejson python-tz python-vatnumber python-vobject python-webdav python-werkzeug python-xlwt python-yaml python-zsi python-docutils python-psutil python-mock python-unittest2 python-jinja2 python-pypdf python-decorator python-requests python-passlib libjpeg-dev -y
+apt-get install build-dep python-imaging python-dateutil python-feedparser python-ldap python-libxslt1 python-lxml python-mako python-openid python-psycopg2 python-pybabel python-pychart python-pydot python-pyparsing python-reportlab python-simplejson python-tz python-vatnumber python-vobject python-webdav python-werkzeug python-xlwt python-yaml python-zsi python-docutils python-psutil python-mock python-unittest2 python-jinja2 python-pypdf python-decorator python-requests python-passlib libjpeg-dev -y
 	
 echo -e "\n---- Install python libraries ----"
 pip install gdata


### PR DESCRIPTION
Python Pillow did not want to compile on my fresh new debian 7.
I added theses two packages : build-dep python-imaging 
(source : http://unix.stackexchange.com/questions/105265/install-pil-pillow-via-pip-in-debian-testing-jessie)

EDIT : sorry I meant you have to install python-imaging with this command : apt-get build-dep python-imaging (build-dep is not a package ><) so then pip install -I pillow will work
