### PR TITLE
Additional script for nightly builds

### DIFF
--- a/ubuntu-14-04/odoo_install_nightly.sh
+++ b/ubuntu-14-04/odoo_install_nightly.sh
@@ -74,7 +74,7 @@ echo -e "\n---- Add package source ----"
 if [[ $OE_VERSION == "8.0" ]]; then
 	if [[ $(grep -c 'deb http://nightly.odoo.com/9.0/nightly/deb/ ./' /etc/apt/sources.list) -eq 1 ]]; then
 		apt-get remove odoo -y
-		sed -n -i 's!deb http://nightly.odoo.com/9.0/nightly/deb/ ./!deb http://nightly.odoo.com/8.0/nightly/deb/ ./!' /etc/apt/sources.list
+		sed -i 's!deb http://nightly.odoo.com/9.0/nightly/deb/ ./!deb http://nightly.odoo.com/8.0/nightly/deb/ ./!' /etc/apt/sources.list
 	elif [[ $(grep -c 'deb http://nightly.odoo.com/8.0/nightly/deb/ ./' /etc/apt/sources.list) -eq 0 ]]; then
 		wget -O - https://nightly.odoo.com/odoo.key | apt-key add -
 		echo "deb http://nightly.odoo.com/8.0/nightly/deb/ ./" >> /etc/apt/sources.list
@@ -82,7 +82,7 @@ if [[ $OE_VERSION == "8.0" ]]; then
 elif [[ $OE_VERSION == "9.0" ]]; then
 	if [[ $(grep -c 'deb http://nightly.odoo.com/8.0/nightly/deb/ ./' /etc/apt/sources.list) -eq 1 ]]; then
 		apt-get remove odoo -y
-		sed -n -i 's!deb http://nightly.odoo.com/8.0/nightly/deb/ ./!deb http://nightly.odoo.com/9.0/nightly/deb/ ./!' /etc/apt/sources.list
+		sed -i 's!deb http://nightly.odoo.com/8.0/nightly/deb/ ./!deb http://nightly.odoo.com/9.0/nightly/deb/ ./!' /etc/apt/sources.list
 	elif [[ $(grep -c 'deb http://nightly.odoo.com/9.0/nightly/deb/ ./' /etc/apt/sources.list) -eq 0 ]]; then
 		wget -O - https://nightly.odoo.com/odoo.key | apt-key add -
 		echo "deb http://nightly.odoo.com/9.0/nightly/deb/ ./" >> /etc/apt/sources.list

--- a/ubuntu-14-04/odoo_install_nightly.sh
+++ b/ubuntu-14-04/odoo_install_nightly.sh
@@ -40,11 +40,11 @@ apt-get install postgresql -y
 echo -e "\n---- Install and link wkhtml as needed for ODOO 8.0 ----"
 wget http://download.gna.org/wkhtmltopdf/0.12/0.12.1/wkhtmltox-0.12.1_linux-trusty-amd64.deb && \
 dpkg -i wkhtmltox-0.12.1_linux-trusty-amd64.deb
-if [[ $? -eq 0 ]]; then
+if [ $? -eq 0 ]; then
 	ln -s /usr/local/bin/wkhtmltopdf /usr/bin/wkhtmltopdf
 	ln -s /usr/local/bin/wkhtmltoimage /usr/bin/wkhtmltoimage
 else
-	echo "\nThe Installation of wkhtml was not successful!" >&2
+	echo "\nThe installation of wkhtml was not successful!" >&2
 	exit 1
 fi
 

--- a/ubuntu-14-04/odoo_install_nightly.sh
+++ b/ubuntu-14-04/odoo_install_nightly.sh
@@ -38,9 +38,6 @@ fi
 # check for 64 Bit or 32 Bit OS
 OS_MACHINE_TYPE=$(uname -m)
 
-# Do I change the version or do I install a completely new odoo?
-OE_VERSION_CHANGE=0
-
 #--------------------------------------------------
 # Update Server
 #--------------------------------------------------
@@ -70,21 +67,21 @@ else
 fi
 
 #--------------------------------------------------
-# Add the package source to the list
+# Add the package source to the list or change it
 #--------------------------------------------------
 echo -e "\n---- Add package source ----"
 if [[ $OE_VERSION -eq "8.0" ]]
 	if [[ $(grep -c 'deb http://nightly.odoo.com/9.0/nightly/deb/ ./' /etc/apt/sources.list) -eq 1 ]]
+		apt-get remove odoo -y
 		sed -n -i 's!deb http://nightly.odoo.com/9.0/nightly/deb/ ./!deb http://nightly.odoo.com/8.0/nightly/deb/ ./!' /etc/apt/sources.list
-		OE_VERSION_CHANGE=1
 	elif [[ $(grep -c 'deb http://nightly.odoo.com/8.0/nightly/deb/ ./' /etc/apt/sources.list) -eq 0 ]]
 		wget -O - https://nightly.odoo.com/odoo.key | apt-key add -
 		echo "deb http://nightly.odoo.com/8.0/nightly/deb/ ./" >> /etc/apt/sources.list
 	fi
 elif [[ $OE_VERSION -eq "9.0" ]]
 	if [[ $(grep -c 'deb http://nightly.odoo.com/8.0/nightly/deb/ ./' /etc/apt/sources.list) -eq 1 ]]
+		apt-get remove odoo -y
 		sed -n -i 's!deb http://nightly.odoo.com/8.0/nightly/deb/ ./!deb http://nightly.odoo.com/9.0/nightly/deb/ ./!' /etc/apt/sources.list
-		OE_VERSION_CHANGE=1
 	elif [[ $(grep -c 'deb http://nightly.odoo.com/9.0/nightly/deb/ ./' /etc/apt/sources.list) -eq 0 ]]
 		wget -O - https://nightly.odoo.com/odoo.key | apt-key add -
 		echo "deb http://nightly.odoo.com/9.0/nightly/deb/ ./" >> /etc/apt/sources.list
@@ -99,9 +96,6 @@ fi
 # Install the actual nightly build of odoo
 #--------------------------------------------------
 echo -e "\n---- Install odoo ----"
-if [[ $OE_VERSION_CHANGE -eq 1 ]]
-	apt-get remove --purge odoo -y
-fi
 apt-get update && apt-get install odoo -y
 
 echo -e "\nDone! The odoo server is installed and should already run."

--- a/ubuntu-14-04/odoo_install_nightly.sh
+++ b/ubuntu-14-04/odoo_install_nightly.sh
@@ -15,3 +15,9 @@
 # EXAMPLE sudo ./odoo_install_nightly.sh
 #
 #################################################################################
+
+# check for root-privileges
+if [[ $EUID -ne 0 ]]; then
+	>&2 echo "You need root privileges to do this!"
+	exit 1
+fi

--- a/ubuntu-14-04/odoo_install_nightly.sh
+++ b/ubuntu-14-04/odoo_install_nightly.sh
@@ -51,6 +51,7 @@ echo -e "\n---- Install PostgreSQL ----"
 apt-get install postgresql -y
 
 echo -e "\n---- Install and link wkhtml as needed for odoo 8.0 ----"
+apt-get install fontconfig libfontconfig1 libjpeg-turbo8 libxrender1 -y
 if [[ $OS_MACHINE_TYPE == "x86_64" ]]; then
 	wget http://download.gna.org/wkhtmltopdf/0.12/0.12.1/wkhtmltox-0.12.1_linux-trusty-amd64.deb && \
 	dpkg -i wkhtmltox-0.12.1_linux-trusty-amd64.deb

--- a/ubuntu-14-04/odoo_install_nightly.sh
+++ b/ubuntu-14-04/odoo_install_nightly.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #################################################################################
-# Script for Installation: ODOO nightly builds on Ubuntu 14.04 LST
+# Script for Installation: ODOO nightly builds on Ubuntu 14.04 LTS
 # Author: (c) Martin Brehmer 2016
 #--------------------------------------------------------------------------------
 #
@@ -17,8 +17,8 @@
 #################################################################################
 
 # check for root-privileges
-if [[ $EUID -ne 0 ]]; then
-	>&2 echo "You need root privileges to do this!"
+if [ $EUID -ne 0 ]; then
+	echo "You need root privileges to do this!" >&2
 	exit 1
 fi
 
@@ -38,10 +38,15 @@ echo -e "\n---- Install PostgreSQL ----"
 apt-get install postgresql -y
 
 echo -e "\n---- Install and link wkhtml as needed for ODOO 8.0 ----"
-wget http://download.gna.org/wkhtmltopdf/0.12/0.12.1/wkhtmltox-0.12.1_linux-trusty-amd64.deb
+wget http://download.gna.org/wkhtmltopdf/0.12/0.12.1/wkhtmltox-0.12.1_linux-trusty-amd64.deb && \
 dpkg -i wkhtmltox-0.12.1_linux-trusty-amd64.deb
-ln -s /usr/local/bin/wkhtmltopdf /usr/bin/wkhtmltopdf
-ln -s /usr/local/bin/wkhtmltoimage /usr/bin/wkhtmltoimage
+if [[ $? -eq 0 ]]; then
+	ln -s /usr/local/bin/wkhtmltopdf /usr/bin/wkhtmltopdf
+	ln -s /usr/local/bin/wkhtmltoimage /usr/bin/wkhtmltoimage
+else
+	echo "\nThe Installation of wkhtml was not successful!" >&2
+	exit 1
+fi
 
 #--------------------------------------------------
 # Add the package source to the list
@@ -56,3 +61,5 @@ echo "deb http://nightly.odoo.com/$OE_VERSION/nightly/deb/ ./" >> /etc/apt/sourc
 apt-get update && apt-get install odoo -y
 
 echo "\nDone! The ODOO server is installed and should already run."
+
+exit 0

--- a/ubuntu-14-04/odoo_install_nightly.sh
+++ b/ubuntu-14-04/odoo_install_nightly.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #################################################################################
-# Script for Installation: ODOO nightly builds on Ubuntu 14.04 LTS
+# Script for Installation: odoo nightly builds on Ubuntu 14.04 LTS
 # Author: (c) Martin Brehmer 2016
 #--------------------------------------------------------------------------------
 #
@@ -28,7 +28,7 @@ if ([[ $# -eq 1 ]] && [[ $1 -ne "8.0" ]] && [[ $1 -ne "9.0" ]]) || ([[ $# -gt 1 
 	exit 1
 fi
 
-# The Version of ODOO you want to install. Default: 8.0
+# The Version of odoo you want to install. Default: 8.0
 if [[ $# -eq 1 ]]; then
 	OE_VERSION="$1"
 else
@@ -47,7 +47,7 @@ apt-get update && apt-get dist-upgrade -y
 echo -e "\n---- Install PostgreSQL ----"
 apt-get install postgresql -y
 
-echo -e "\n---- Install and link wkhtml as needed for ODOO 8.0 ----"
+echo -e "\n---- Install and link wkhtml as needed for odoo 8.0 ----"
 wget http://download.gna.org/wkhtmltopdf/0.12/0.12.1/wkhtmltox-0.12.1_linux-trusty-amd64.deb && \
 dpkg -i wkhtmltox-0.12.1_linux-trusty-amd64.deb
 if [[ $? -eq 0 ]]; then
@@ -66,10 +66,11 @@ wget -O - https://nightly.odoo.com/odoo.key | apt-key add -
 echo "deb http://nightly.odoo.com/$OE_VERSION/nightly/deb/ ./" >> /etc/apt/sources.list
 
 #--------------------------------------------------
-# Install the actual nightly build of ODOO
+# Install the actual nightly build of odoo
 #--------------------------------------------------
+echo -e "\n---- Install odoo ----"
 apt-get update && apt-get install odoo -y
 
-echo "\nDone! The ODOO server is installed and should already run."
+echo "\nDone! The odoo server is installed and should already run."
 
 exit 0

--- a/ubuntu-14-04/odoo_install_nightly.sh
+++ b/ubuntu-14-04/odoo_install_nightly.sh
@@ -10,20 +10,30 @@
 #
 #--------------------------------------------------------------------------------
 #
-# USAGE: (sudo) odoo_install_nightly.sh
+# USAGE: (sudo) odoo_install_nightly.sh [8.0|9.0]
 #
-# EXAMPLE: sudo ./odoo_install_nightly.sh
+# EXAMPLE: sudo ./odoo_install_nightly.sh 8.0
 #
 #################################################################################
 
 # check for root-privileges
-if [ $EUID -ne 0 ]; then
+if [[ $EUID -ne 0 ]]; then
 	echo "You need root privileges to do this!" >&2
 	exit 1
 fi
 
-# Enter the Version you want to install. Possible values are 8.0 or 9.0
-OE_VERSION="8.0"
+# check for invalid or too many parameters
+if ([[ $# -eq 1 ]] && [[ $1 -ne "8.0" ]] && [[ $1 -ne "9.0" ]]) || ([[ $# -gt 1 ]]); then
+	echo "USAGE: $0 [8.0|9.0]"
+	exit 1
+fi
+
+# The Version of ODOO you want to install. Default: 8.0
+if [[ $# -eq 1 ]]; then
+	OE_VERSION="$1"
+else
+	OE_VERSION="8.0"
+fi
 
 #--------------------------------------------------
 # Update Server
@@ -40,7 +50,7 @@ apt-get install postgresql -y
 echo -e "\n---- Install and link wkhtml as needed for ODOO 8.0 ----"
 wget http://download.gna.org/wkhtmltopdf/0.12/0.12.1/wkhtmltox-0.12.1_linux-trusty-amd64.deb && \
 dpkg -i wkhtmltox-0.12.1_linux-trusty-amd64.deb
-if [ $? -eq 0 ]; then
+if [[ $? -eq 0 ]]; then
 	ln -s /usr/local/bin/wkhtmltopdf /usr/bin/wkhtmltopdf
 	ln -s /usr/local/bin/wkhtmltoimage /usr/bin/wkhtmltoimage
 else

--- a/ubuntu-14-04/odoo_install_nightly.sh
+++ b/ubuntu-14-04/odoo_install_nightly.sh
@@ -51,7 +51,7 @@ echo -e "\n---- Install PostgreSQL ----"
 apt-get install postgresql -y
 
 echo -e "\n---- Install and link wkhtml as needed for odoo 8.0 ----"
-apt-get install fontconfig libfontconfig1 libjpeg-turbo8 libxrender1 -y
+apt-get install fontconfig fontconfig-config fonts-dejavu-core libfontconfig1 libjpeg-turbo8 libxrender1 -y
 if [[ $OS_MACHINE_TYPE == "x86_64" ]]; then
 	wget http://download.gna.org/wkhtmltopdf/0.12/0.12.1/wkhtmltox-0.12.1_linux-trusty-amd64.deb && \
 	dpkg -i wkhtmltox-0.12.1_linux-trusty-amd64.deb

--- a/ubuntu-14-04/odoo_install_nightly.sh
+++ b/ubuntu-14-04/odoo_install_nightly.sh
@@ -30,3 +30,12 @@ OE_VERSION="8.0"
 #--------------------------------------------------
 echo -e "\n---- Update Server ----"
 apt-get update && apt-get dist-upgrade -y
+
+#--------------------------------------------------
+# Install Dependencies
+#--------------------------------------------------
+echo -e "\n---- Install and link wkhtml as needed for ODOO 8.0"
+wget http://download.gna.org/wkhtmltopdf/0.12/0.12.1/wkhtmltox-0.12.1_linux-trusty-amd64.deb
+dpkg -i wkhtmltox-0.12.1_linux-trusty-amd64.deb
+ln -s /usr/local/bin/wkhtmltopdf /usr/bin/wkhtmltopdf
+ln -s /usr/local/bin/wkhtmltoimage /usr/bin/wkhtmltoimage

--- a/ubuntu-14-04/odoo_install_nightly.sh
+++ b/ubuntu-14-04/odoo_install_nightly.sh
@@ -72,7 +72,7 @@ fi
 #--------------------------------------------------
 echo -e "\n---- Add package source ----"
 if [[ $OE_VERSION == "8.0" ]]; then
-	if [[ $(grep -c 'deb http://nightly.odoo.com/9.0/nightly/deb/ ./' /etc/apt/sources.list) -eq 1 ]]
+	if [[ $(grep -c 'deb http://nightly.odoo.com/9.0/nightly/deb/ ./' /etc/apt/sources.list) -eq 1 ]]; then
 		apt-get remove odoo -y
 		sed -n -i 's!deb http://nightly.odoo.com/9.0/nightly/deb/ ./!deb http://nightly.odoo.com/8.0/nightly/deb/ ./!' /etc/apt/sources.list
 	elif [[ $(grep -c 'deb http://nightly.odoo.com/8.0/nightly/deb/ ./' /etc/apt/sources.list) -eq 0 ]]; then
@@ -80,7 +80,7 @@ if [[ $OE_VERSION == "8.0" ]]; then
 		echo "deb http://nightly.odoo.com/8.0/nightly/deb/ ./" >> /etc/apt/sources.list
 	fi
 elif [[ $OE_VERSION == "9.0" ]]; then
-	if [[ $(grep -c 'deb http://nightly.odoo.com/8.0/nightly/deb/ ./' /etc/apt/sources.list) -eq 1 ]]
+	if [[ $(grep -c 'deb http://nightly.odoo.com/8.0/nightly/deb/ ./' /etc/apt/sources.list) -eq 1 ]]; then
 		apt-get remove odoo -y
 		sed -n -i 's!deb http://nightly.odoo.com/8.0/nightly/deb/ ./!deb http://nightly.odoo.com/9.0/nightly/deb/ ./!' /etc/apt/sources.list
 	elif [[ $(grep -c 'deb http://nightly.odoo.com/9.0/nightly/deb/ ./' /etc/apt/sources.list) -eq 0 ]]; then

--- a/ubuntu-14-04/odoo_install_nightly.sh
+++ b/ubuntu-14-04/odoo_install_nightly.sh
@@ -51,7 +51,7 @@ echo -e "\n---- Install PostgreSQL ----"
 apt-get install postgresql -y
 
 echo -e "\n---- Install and link wkhtml as needed for odoo 8.0 ----"
-if [[ $OS_MACHINE_TYPE -eq "x86_64" ]]
+if [[ $OS_MACHINE_TYPE -eq "x86_64" ]]; then
 	wget http://download.gna.org/wkhtmltopdf/0.12/0.12.1/wkhtmltox-0.12.1_linux-trusty-amd64.deb && \
 	dpkg -i wkhtmltox-0.12.1_linux-trusty-amd64.deb
 else
@@ -70,19 +70,19 @@ fi
 # Add the package source to the list or change it
 #--------------------------------------------------
 echo -e "\n---- Add package source ----"
-if [[ $OE_VERSION -eq "8.0" ]]
+if [[ $OE_VERSION -eq "8.0" ]]; then
 	if [[ $(grep -c 'deb http://nightly.odoo.com/9.0/nightly/deb/ ./' /etc/apt/sources.list) -eq 1 ]]
 		apt-get remove odoo -y
 		sed -n -i 's!deb http://nightly.odoo.com/9.0/nightly/deb/ ./!deb http://nightly.odoo.com/8.0/nightly/deb/ ./!' /etc/apt/sources.list
-	elif [[ $(grep -c 'deb http://nightly.odoo.com/8.0/nightly/deb/ ./' /etc/apt/sources.list) -eq 0 ]]
+	elif [[ $(grep -c 'deb http://nightly.odoo.com/8.0/nightly/deb/ ./' /etc/apt/sources.list) -eq 0 ]]; then
 		wget -O - https://nightly.odoo.com/odoo.key | apt-key add -
 		echo "deb http://nightly.odoo.com/8.0/nightly/deb/ ./" >> /etc/apt/sources.list
 	fi
-elif [[ $OE_VERSION -eq "9.0" ]]
+elif [[ $OE_VERSION -eq "9.0" ]]; then
 	if [[ $(grep -c 'deb http://nightly.odoo.com/8.0/nightly/deb/ ./' /etc/apt/sources.list) -eq 1 ]]
 		apt-get remove odoo -y
 		sed -n -i 's!deb http://nightly.odoo.com/8.0/nightly/deb/ ./!deb http://nightly.odoo.com/9.0/nightly/deb/ ./!' /etc/apt/sources.list
-	elif [[ $(grep -c 'deb http://nightly.odoo.com/9.0/nightly/deb/ ./' /etc/apt/sources.list) -eq 0 ]]
+	elif [[ $(grep -c 'deb http://nightly.odoo.com/9.0/nightly/deb/ ./' /etc/apt/sources.list) -eq 0 ]]; then
 		wget -O - https://nightly.odoo.com/odoo.key | apt-key add -
 		echo "deb http://nightly.odoo.com/9.0/nightly/deb/ ./" >> /etc/apt/sources.list
 	fi

--- a/ubuntu-14-04/odoo_install_nightly.sh
+++ b/ubuntu-14-04/odoo_install_nightly.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+#################################################################################
+# Script for Installation: ODOO nightly builds on Ubuntu 14.04 LST
+# Author: (c) Martin Brehmer 2016
+#--------------------------------------------------------------------------------
+#
+# This script will install ODOO from the package sources for the nightly builds
+# on a clean Ubuntu 14.04 Server
+#
+#--------------------------------------------------------------------------------
+#
+# USAGE: (sudo) odoo_install_nightly.sh
+#
+# EXAMPLE sudo ./odoo_install_nightly.sh
+#
+#################################################################################

--- a/ubuntu-14-04/odoo_install_nightly.sh
+++ b/ubuntu-14-04/odoo_install_nightly.sh
@@ -35,6 +35,9 @@ else
 	OE_VERSION="8.0"
 fi
 
+# check for 64 Bit or 32 Bit OS
+OS_MACHINE_TYPE=$(uname -m)
+
 #--------------------------------------------------
 # Update Server
 #--------------------------------------------------
@@ -48,8 +51,13 @@ echo -e "\n---- Install PostgreSQL ----"
 apt-get install postgresql -y
 
 echo -e "\n---- Install and link wkhtml as needed for odoo 8.0 ----"
-wget http://download.gna.org/wkhtmltopdf/0.12/0.12.1/wkhtmltox-0.12.1_linux-trusty-amd64.deb && \
-dpkg -i wkhtmltox-0.12.1_linux-trusty-amd64.deb
+if [[ $OS_MACHINE_TYPE -eq "x86_64" ]]
+	wget http://download.gna.org/wkhtmltopdf/0.12/0.12.1/wkhtmltox-0.12.1_linux-trusty-amd64.deb && \
+	dpkg -i wkhtmltox-0.12.1_linux-trusty-amd64.deb
+else
+	wget http://download.gna.org/wkhtmltopdf/0.12/0.12.1/wkhtmltox-0.12.1_linux-trusty-i386.deb && \
+	dpkg -i wkhtmltox-0.12.1_linux-trusty-i386.deb
+fi
 if [[ $? -eq 0 ]]; then
 	ln -s /usr/local/bin/wkhtmltopdf /usr/bin/wkhtmltopdf
 	ln -s /usr/local/bin/wkhtmltoimage /usr/bin/wkhtmltoimage

--- a/ubuntu-14-04/odoo_install_nightly.sh
+++ b/ubuntu-14-04/odoo_install_nightly.sh
@@ -12,7 +12,7 @@
 #
 # USAGE: (sudo) odoo_install_nightly.sh
 #
-# EXAMPLE sudo ./odoo_install_nightly.sh
+# EXAMPLE: sudo ./odoo_install_nightly.sh
 #
 #################################################################################
 
@@ -22,7 +22,7 @@ if [[ $EUID -ne 0 ]]; then
 	exit 1
 fi
 
-# Enter the Version you want to install. Possible values: 7.0, 8.0, 9.0
+# Enter the Version you want to install. Possible values are 8.0 or 9.0
 OE_VERSION="8.0"
 
 #--------------------------------------------------
@@ -34,8 +34,25 @@ apt-get update && apt-get dist-upgrade -y
 #--------------------------------------------------
 # Install Dependencies
 #--------------------------------------------------
-echo -e "\n---- Install and link wkhtml as needed for ODOO 8.0"
+echo -e "\n---- Install PostgreSQL ----"
+apt-get install postgresql -y
+
+echo -e "\n---- Install and link wkhtml as needed for ODOO 8.0 ----"
 wget http://download.gna.org/wkhtmltopdf/0.12/0.12.1/wkhtmltox-0.12.1_linux-trusty-amd64.deb
 dpkg -i wkhtmltox-0.12.1_linux-trusty-amd64.deb
 ln -s /usr/local/bin/wkhtmltopdf /usr/bin/wkhtmltopdf
 ln -s /usr/local/bin/wkhtmltoimage /usr/bin/wkhtmltoimage
+
+#--------------------------------------------------
+# Add the package source to the list
+#--------------------------------------------------
+echo -e "\n---- Add package source ----"
+wget -O - https://nightly.odoo.com/odoo.key | apt-key add -
+echo "deb http://nightly.odoo.com/$OE_VERSION/nightly/deb/ ./" >> /etc/apt/sources.list
+
+#--------------------------------------------------
+# Install the actual nightly build of ODOO
+#--------------------------------------------------
+apt-get update && apt-get install odoo -y
+
+echo "\nDone! The ODOO server is installed and should already run."

--- a/ubuntu-14-04/odoo_install_nightly.sh
+++ b/ubuntu-14-04/odoo_install_nightly.sh
@@ -70,8 +70,25 @@ fi
 # Add the package source to the list
 #--------------------------------------------------
 echo -e "\n---- Add package source ----"
-wget -O - https://nightly.odoo.com/odoo.key | apt-key add -
-echo "deb http://nightly.odoo.com/$OE_VERSION/nightly/deb/ ./" >> /etc/apt/sources.list
+if [[ $OE_VERSION -eq "8.0" ]]
+	if [[ $(grep -c 'deb http://nightly.odoo.com/9.0/nightly/deb/ ./' /etc/apt/sources.list) -eq 1 ]]
+		sed -n -i 's!deb http://nightly.odoo.com/9.0/nightly/deb/ ./!deb http://nightly.odoo.com/8.0/nightly/deb/ ./!' /etc/apt/sources.list
+	elif [[ $(grep -c 'deb http://nightly.odoo.com/8.0/nightly/deb/ ./' /etc/apt/sources.list) -eq 0 ]]
+		wget -O - https://nightly.odoo.com/odoo.key | apt-key add -
+		echo "deb http://nightly.odoo.com/8.0/nightly/deb/ ./" >> /etc/apt/sources.list
+	fi
+elif [[ $OE_VERSION -eq "9.0" ]]
+	if [[ $(grep -c 'deb http://nightly.odoo.com/8.0/nightly/deb/ ./' /etc/apt/sources.list) -eq 1 ]]
+		sed -n -i 's!deb http://nightly.odoo.com/8.0/nightly/deb/ ./!deb http://nightly.odoo.com/9.0/nightly/deb/ ./!' /etc/apt/sources.list
+	elif [[ $(grep -c 'deb http://nightly.odoo.com/9.0/nightly/deb/ ./' /etc/apt/sources.list) -eq 0 ]]
+		wget -O - https://nightly.odoo.com/odoo.key | apt-key add -
+		echo "deb http://nightly.odoo.com/9.0/nightly/deb/ ./" >> /etc/apt/sources.list
+	fi
+else
+	echo -e "\n Unsopported version number for odoo" >&2
+	echo "USAGE: $0 [8.0|9.0]"
+	exit 1
+fi
 
 #--------------------------------------------------
 # Install the actual nightly build of odoo

--- a/ubuntu-14-04/odoo_install_nightly.sh
+++ b/ubuntu-14-04/odoo_install_nightly.sh
@@ -38,6 +38,9 @@ fi
 # check for 64 Bit or 32 Bit OS
 OS_MACHINE_TYPE=$(uname -m)
 
+# Do I change the version or do I install a completely new odoo?
+OE_VERSION_CHANGE=0
+
 #--------------------------------------------------
 # Update Server
 #--------------------------------------------------
@@ -73,6 +76,7 @@ echo -e "\n---- Add package source ----"
 if [[ $OE_VERSION -eq "8.0" ]]
 	if [[ $(grep -c 'deb http://nightly.odoo.com/9.0/nightly/deb/ ./' /etc/apt/sources.list) -eq 1 ]]
 		sed -n -i 's!deb http://nightly.odoo.com/9.0/nightly/deb/ ./!deb http://nightly.odoo.com/8.0/nightly/deb/ ./!' /etc/apt/sources.list
+		OE_VERSION_CHANGE=1
 	elif [[ $(grep -c 'deb http://nightly.odoo.com/8.0/nightly/deb/ ./' /etc/apt/sources.list) -eq 0 ]]
 		wget -O - https://nightly.odoo.com/odoo.key | apt-key add -
 		echo "deb http://nightly.odoo.com/8.0/nightly/deb/ ./" >> /etc/apt/sources.list
@@ -80,6 +84,7 @@ if [[ $OE_VERSION -eq "8.0" ]]
 elif [[ $OE_VERSION -eq "9.0" ]]
 	if [[ $(grep -c 'deb http://nightly.odoo.com/8.0/nightly/deb/ ./' /etc/apt/sources.list) -eq 1 ]]
 		sed -n -i 's!deb http://nightly.odoo.com/8.0/nightly/deb/ ./!deb http://nightly.odoo.com/9.0/nightly/deb/ ./!' /etc/apt/sources.list
+		OE_VERSION_CHANGE=1
 	elif [[ $(grep -c 'deb http://nightly.odoo.com/9.0/nightly/deb/ ./' /etc/apt/sources.list) -eq 0 ]]
 		wget -O - https://nightly.odoo.com/odoo.key | apt-key add -
 		echo "deb http://nightly.odoo.com/9.0/nightly/deb/ ./" >> /etc/apt/sources.list
@@ -94,6 +99,9 @@ fi
 # Install the actual nightly build of odoo
 #--------------------------------------------------
 echo -e "\n---- Install odoo ----"
+if [[ $OE_VERSION_CHANGE -eq 1 ]]
+	apt-get remove --purge odoo -y
+fi
 apt-get update && apt-get install odoo -y
 
 echo -e "\nDone! The odoo server is installed and should already run."

--- a/ubuntu-14-04/odoo_install_nightly.sh
+++ b/ubuntu-14-04/odoo_install_nightly.sh
@@ -23,7 +23,7 @@ if [[ $EUID -ne 0 ]]; then
 fi
 
 # check for invalid or too many parameters
-if ([[ $# -eq 1 ]] && [[ $1 -ne "8.0" ]] && [[ $1 -ne "9.0" ]]) || ([[ $# -gt 1 ]]); then
+if ([[ $# -eq 1 ]] && [[ $1 != "8.0" ]] && [[ $1 != "9.0" ]]) || ([[ $# -gt 1 ]]); then
 	echo "USAGE: $0 [8.0|9.0]"
 	exit 1
 fi
@@ -51,7 +51,7 @@ echo -e "\n---- Install PostgreSQL ----"
 apt-get install postgresql -y
 
 echo -e "\n---- Install and link wkhtml as needed for odoo 8.0 ----"
-if [[ $OS_MACHINE_TYPE -eq "x86_64" ]]; then
+if [[ $OS_MACHINE_TYPE == "x86_64" ]]; then
 	wget http://download.gna.org/wkhtmltopdf/0.12/0.12.1/wkhtmltox-0.12.1_linux-trusty-amd64.deb && \
 	dpkg -i wkhtmltox-0.12.1_linux-trusty-amd64.deb
 else
@@ -70,7 +70,7 @@ fi
 # Add the package source to the list or change it
 #--------------------------------------------------
 echo -e "\n---- Add package source ----"
-if [[ $OE_VERSION -eq "8.0" ]]; then
+if [[ $OE_VERSION == "8.0" ]]; then
 	if [[ $(grep -c 'deb http://nightly.odoo.com/9.0/nightly/deb/ ./' /etc/apt/sources.list) -eq 1 ]]
 		apt-get remove odoo -y
 		sed -n -i 's!deb http://nightly.odoo.com/9.0/nightly/deb/ ./!deb http://nightly.odoo.com/8.0/nightly/deb/ ./!' /etc/apt/sources.list
@@ -78,7 +78,7 @@ if [[ $OE_VERSION -eq "8.0" ]]; then
 		wget -O - https://nightly.odoo.com/odoo.key | apt-key add -
 		echo "deb http://nightly.odoo.com/8.0/nightly/deb/ ./" >> /etc/apt/sources.list
 	fi
-elif [[ $OE_VERSION -eq "9.0" ]]; then
+elif [[ $OE_VERSION == "9.0" ]]; then
 	if [[ $(grep -c 'deb http://nightly.odoo.com/8.0/nightly/deb/ ./' /etc/apt/sources.list) -eq 1 ]]
 		apt-get remove odoo -y
 		sed -n -i 's!deb http://nightly.odoo.com/8.0/nightly/deb/ ./!deb http://nightly.odoo.com/9.0/nightly/deb/ ./!' /etc/apt/sources.list

--- a/ubuntu-14-04/odoo_install_nightly.sh
+++ b/ubuntu-14-04/odoo_install_nightly.sh
@@ -2,7 +2,7 @@
 
 #################################################################################
 # Script for Installation: odoo nightly builds on Ubuntu 14.04 LTS
-# Author: (c) Martin Brehmer 2016
+# Author: (c) 2016 Martin Brehmer
 #--------------------------------------------------------------------------------
 #
 # This script will install ODOO from the package sources for the nightly builds
@@ -62,7 +62,7 @@ if [[ $? -eq 0 ]]; then
 	ln -s /usr/local/bin/wkhtmltopdf /usr/bin/wkhtmltopdf
 	ln -s /usr/local/bin/wkhtmltoimage /usr/bin/wkhtmltoimage
 else
-	echo "\nThe installation of wkhtml was not successful!" >&2
+	echo -e "\nThe installation of wkhtml was not successful!" >&2
 	exit 1
 fi
 
@@ -79,6 +79,6 @@ echo "deb http://nightly.odoo.com/$OE_VERSION/nightly/deb/ ./" >> /etc/apt/sourc
 echo -e "\n---- Install odoo ----"
 apt-get update && apt-get install odoo -y
 
-echo "\nDone! The odoo server is installed and should already run."
+echo -e "\nDone! The odoo server is installed and should already run."
 
 exit 0

--- a/ubuntu-14-04/odoo_install_nightly.sh
+++ b/ubuntu-14-04/odoo_install_nightly.sh
@@ -21,3 +21,12 @@ if [[ $EUID -ne 0 ]]; then
 	>&2 echo "You need root privileges to do this!"
 	exit 1
 fi
+
+# Enter the Version you want to install. Possible values: 7.0, 8.0, 9.0
+OE_VERSION="8.0"
+
+#--------------------------------------------------
+# Update Server
+#--------------------------------------------------
+echo -e "\n---- Update Server ----"
+apt-get update && apt-get dist-upgrade -y


### PR DESCRIPTION
This adds a new script to the Repository, which can install or even change between odoo 8.0 and odoo 9.0.

Instead of using the sourcecode from GitHub, it uses the package sources for Debian-like systems. In this way the nightly updates can simply be installed by using apt-get (dist-)upgrade.

By default this script installs oddo 8.0. If you want to install 9.0, or change from 8.0 to 9.0, simply add 9.0 as a parameter. You can also use this script, if you want to change from 9.0 to 8.0. Both directions are possible.

Another feature of the new script is that it can also be used for old 32-Bit systems, if needed. That was an requirement from my client.

I have developed and tested this script on Ubuntu 14.04 64-Bit and Ubuntu 14.04 32-Bit. It works fine on both systems.